### PR TITLE
Fix continuous monitor bugs.

### DIFF
--- a/plot_continuous_monitor.py
+++ b/plot_continuous_monitor.py
@@ -77,16 +77,17 @@ def plot_continuous_monitor(filename, open_graphs=False):
     running_compute_monotasks = 0
     if "Running Compute Monotasks" in json_data:
       running_compute_monotasks = json_data["Running Compute Monotasks"]
+    xvdf_running_disk_monotasks = 0
+    xvdb_running_disk_monotasks = 0
+    if "Running Disk Monotasks" in json_data:
+      # Parse the number of currently running disk monotasks for each disk. xvdf is mounted on /mnt2
+      # and xvdb on /mnt (the indexing below will need to be updated if we use different instance
+      # types).
+      running_disk_monotasks_info = json_data["Running Disk Monotasks"]
+      RUNNING_MONOTASKS_KEY = "Running And Queued Monotasks"
+      xvdf_running_disk_monotasks = running_disk_monotasks_info[0][RUNNING_MONOTASKS_KEY]
+      xvdb_running_disk_monotasks = running_disk_monotasks_info[1][RUNNING_MONOTASKS_KEY]
     running_macrotasks = 0
-
-    # Parse the number of currently running disk monotasks for each disk.
-    # xvdf is mounted on /mnt2 and xvdb on /mnt (the indexing below will need to be updated
-    # if we use different instance types).
-    running_disk_monotasks_info = json_data["Running Disk Monotasks"]
-    RUNNING_MONOTASKS_KEY = "Running And Queued Monotasks"
-    xvdf_running_disk_monotasks = running_disk_monotasks_info[0][RUNNING_MONOTASKS_KEY]
-    xvdb_running_disk_monotasks = running_disk_monotasks_info[1][RUNNING_MONOTASKS_KEY]
-
     if "Running Macrotasks" in json_data:
       running_macrotasks = json_data["Running Macrotasks"]
     gc_fraction = 0

--- a/plot_continuous_monitor.py
+++ b/plot_continuous_monitor.py
@@ -1,3 +1,4 @@
+import argparse
 import inspect
 import json
 import os


### PR DESCRIPTION
Fixes two bugs in `parse_continuous_monitor.py`:
1.  Unable to find `"Running Disk Monotasks"` in Spark JSON data.
2.  Missing import: `argparse`
