### PR TITLE
Make copy_logs.py use old subprocess API.

### DIFF
--- a/copy_logs.py
+++ b/copy_logs.py
@@ -19,7 +19,7 @@ def ssh_get_stdout(host, identity_file, username, command):
   command = "source /root/.bash_profile; %s" % command
   ssh_command = ("ssh -t -o StrictHostKeyChecking=no -i %s %s@%s '%s'" %
     (identity_file, username, host, command))
-  return subprocess.check_output(ssh_command, shell=True)
+  return subprocess.Popen(ssh_command, stdout=subprocess.PIPE, shell=True).communicate()[0]
 
 def copy_logs(argv):
   """ Copies logs back from a Spark cluster.


### PR DESCRIPTION
This commit modifies copy_logs.py so that it does not use the
subprocess.check_output() function, which is not present in the version
of Python that is installed by default on the m2.4xlarge EC2 machines
that we use. copy_logs.py has been refactored to use subprocess.Popen()
instead.
