### PR TITLE
Fix miscellaneous problems in plot_matplotlib.py

### DIFF
--- a/plot_continuous_monitor.py
+++ b/plot_continuous_monitor.py
@@ -158,8 +158,8 @@ def plot_continuous_monitor(filename, open_graphs=False, use_gnuplot=False):
   if use_gnuplot:
     plot_gnuplot.plot(continuous_monitor_data, filename, open_graphs, disks_to_index)
   else:
-    plot_matplotlib.plot([dict(line) for line in continuous_monitor_data],
-                         filename, open_graphs)
+    plot_matplotlib.plot([dict(line) for line in continuous_monitor_data], filename, open_graphs,
+                         disks_to_index.iterkeys())
 
 
 def get_util_for_disk(disk_utils, disk):


### PR DESCRIPTION
This commit refactors plot_matplotlib.py to accomplish the following:
- each graph is saved in its own file
- graph legends do not obscure the graphs themselves
- disk names are determined automatically
- remove extraneous class names from legend strings
- when using the "--open-graphs" option, show all graphs at once
- minimize the code contained within the "with" block
- in the Utilization graph, replace disk throughput with disk
  utilization
- style fixes
